### PR TITLE
Add support for the minimum heat setting where supported

### DIFF
--- a/custom_components/fujitsu_airstage/const.py
+++ b/custom_components/fujitsu_airstage/const.py
@@ -18,6 +18,9 @@ VERTICAL_LOWEST = "Lowest"
 FAN_QUIET = "Quiet"
 
 
+MINIMUM_HEAT = "Minimum Heat"
+
+
 CONF_LOCAL = "local"
 CONF_CLOUD = "cloud"
 CONF_SELECT_POLLING = "select_polling"


### PR DESCRIPTION
This adds the minimum heat setting as a preset and resolves #27.

Given it alters the operation of the unit and the target temperature, it seemed to make more conceptual sense as a preset than a switch. It's odd that there's not an HVACMode for frost protect, but cést la vie.

Thanks very much!