### PR TITLE
turn on hvac when setting temp (if hvac is off)

### DIFF
--- a/custom_components/fujitsu_airstage/climate.py
+++ b/custom_components/fujitsu_airstage/climate.py
@@ -152,6 +152,8 @@ class AirstageAC(AirstageAcEntity, ClimateEntity):
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
+        if self.hvac_mode == HVACMode.OFF:
+            await self.async_turn_on()
 
         if self.hvac_mode != HVACMode.FAN_ONLY:
             await self._ac.set_target_temperature(kwargs.get(ATTR_TEMPERATURE))


### PR DESCRIPTION
For UI perspective this makes sense to me. If you set the temperature, HVAC should turn on if it isn't on already.
I'm not sure if there are any concerns to make this the default behavior?

Could resolve this: https://github.com/danielkaldheim/ha_airstage/issues/36