### PR TITLE
fix(dhcp): bind use_https in DHCP discovery flow

### DIFF
--- a/custom_components/fujitsu_airstage/config_flow.py
+++ b/custom_components/fujitsu_airstage/config_flow.py
@@ -105,9 +105,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         for entry in self._async_current_entries():
             if entry.data.get(CONF_DEVICE_ID) == mac.replace(":", "").upper():
-                # Device is already configured, check if IP or use_https changed
+                # Device is already configured, check if the IP changed.
+                # DHCP discovery carries no HTTPS information, so the entry's
+                # existing setting is preserved as-is via the spread below.
                 old_ip = entry.data.get(CONF_IP_ADDRESS)
-                old_use_https = entry.data.get(CONF_USE_HTTPS)
 
                 if old_ip != ip:
                     _LOGGER.info(
@@ -119,7 +120,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     new_data = {
                         **entry.data,
                         CONF_IP_ADDRESS: ip,
-                        CONF_USE_HTTPS: use_https,
                     }
                     self.hass.config_entries.async_update_entry(
                         entry,
@@ -132,7 +132,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         user_data = {
             CONF_DEVICE_ID: device_id,
             CONF_IP_ADDRESS: ip,
-            CONF_USE_HTTPS: use_https,
+            # Discovery cannot tell whether the device speaks HTTPS; default to
+            # plain HTTP, matching IP_SCHEMA's default for the manual flow.
+            CONF_USE_HTTPS: False,
         }
 
         # Test to see if we can connect to the device


### PR DESCRIPTION
### Summary

`ConfigFlow.async_step_dhcp` reads `use_https` in two places but never assigns it, so the name is unbound at runtime. Introduced in b9ce77c (HTTPS support), shipped in **1.8.0 and 1.8.1**.

Both branches of the step raise `NameError`:

| Situation | Where it fires | User-visible effect |
|---|---|---|
| Known device, IP changed | building `new_data`, *before* `async_update_entry` | the error propagates out of the step and **the IP is never updated** |
| Unknown device | building `user_data` | caught by the broad `except Exception` below and reported as `not_a_fujitsu_airstage`, so **a genuine Airstage unit is rejected with a misleading reason** |

The second one is the nastier of the two — the failure is swallowed, so it reads as "this isn't a Fujitsu device" rather than as a bug.

The first case is also exactly the behaviour requested in #83 (*Automatically update IP for known devices*): the code to do it is already there, it has just been unreachable since March.

### Fix

DHCP discovery carries no HTTPS information, so there is nothing meaningful to compare against:

- **existing entry** — leave the value untouched. The `**entry.data` spread already carries it, so the explicit `CONF_USE_HTTPS` key and the (also unused) `old_use_https` local are dropped. Note this is slightly better than assigning `old_use_https`: for entries created before 1.8.0 that key is absent, and writing `None` into the entry would then be passed to `ApiLocal(use_https=None)`.
- **new entry** — default to `False`, matching `IP_SCHEMA`'s `vol.Optional(CONF_USE_HTTPS, default=False)` in the manual flow.

Six lines, three of them comments.

### Verification

I walked the module's AST looking for names loaded without ever being bound in their scope:

```
before:  ConfigFlow.async_step_dhcp: unbound 'use_https' at line 122
         ConfigFlow.async_step_dhcp: unbound 'use_https' at line 135
after:   no unbound local names found
```

I don't have a DHCP-discoverable unit on hand to exercise the flow end to end, so this is static verification only — worth a sanity check from someone who can trigger discovery.

### Notes

Happy to fold in a regression test for `async_step_dhcp` if you'd like one; the repo has no test suite today so I left it out rather than introduce scaffolding unasked.
