### PR TITLE
chore(translations): remove duplicate "step" key in config block

### DIFF
--- a/custom_components/fujitsu_airstage/strings.json
+++ b/custom_components/fujitsu_airstage/strings.json
@@ -10,13 +10,6 @@
   },
   "config": {
     "step": {
-      "init": {
-        "data": {
-          "conf_use_https": "Use HTTPS to connect to device"
-        }
-      }
-    },
-    "step": {
       "details": {
         "data": {
           "local": "[%key:common::config_flow::data::local%]",

--- a/custom_components/fujitsu_airstage/translations/en.json
+++ b/custom_components/fujitsu_airstage/translations/en.json
@@ -10,13 +10,6 @@
   },
   "config": {
     "step": {
-      "init": {
-        "data": {
-          "conf_use_https": "Use HTTPS to connect to device"
-        }
-      }
-    },
-    "step": {
       "details": {
         "data": {
           "local": "Local",

--- a/custom_components/fujitsu_airstage/translations/nl.json
+++ b/custom_components/fujitsu_airstage/translations/nl.json
@@ -10,13 +10,6 @@
   },
   "config": {
     "step": {
-      "init": {
-        "data": {
-          "conf_use_https": "Gebruik HTTPS om verbinding te maken met het apparaat"
-        }
-      }
-    },
-    "step": {
       "details": {
         "data": {
           "local": "Lokaal",


### PR DESCRIPTION
### Summary

`strings.json`, `translations/en.json` and `translations/nl.json` each declare `"step"` **twice** inside `"config"`. A JSON object cannot hold a duplicate key: every parser keeps the last occurrence, so the first block — `config.step.init` — is silently discarded before Home Assistant ever sees it.

That block is dead in two independent ways:

1. **The config flow has no `init` step.** `ConfigFlow` defines `async_step_user`, `async_step_details`, `async_step_dhcp` and `async_step_reconfigure`. `async_step_init` belongs to `OptionsFlow`, which is already covered by the separate top-level `"options"` block.
2. **It is the first of the two duplicates**, so it is dropped at parse time regardless.

### Verification

Parsing each file before and after, with a hook that reports duplicate keys:

```
strings.json   BEFORE duplicates=['step']  AFTER none  ->  parsed result identical: True
en.json        BEFORE duplicates=['step']  AFTER none  ->  parsed result identical: True
nl.json        BEFORE duplicates=['step']  AFTER none  ->  parsed result identical: True
```

So this is a **no-op at runtime**. The only effect is that the files stop carrying a duplicate key, which linters and strict JSON tooling flag.

### On the commit type

Typed `chore` rather than `fix` on purpose: nothing changes behaviourally, and `fix` would trigger a patch release through semantic-release for a cosmetic cleanup. Happy to retitle if you'd rather it ride in one.

### Note

The `conf_use_https` label itself is *not* lost by this change — it is already declared in the `details`, `user` and `reconfigure` steps, which are the steps that actually render the field.
