### PR TITLE
fix(coordinator): raise UpdateFailed from update methods

### DIFF
--- a/custom_components/fujitsu_airstage/__init__.py
+++ b/custom_components/fujitsu_airstage/__init__.py
@@ -18,9 +18,11 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady, PlatformNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import (
+    DataUpdateCoordinator,
+    UpdateFailed,
+)
 
 from .const import (
     AIRSTAGE_LOCAL_RETRY,
@@ -70,7 +72,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             try:
                 return await apiCloud.get_devices()
             except airstage_api.ApiError as err:
-                raise PlatformNotReady(
+                raise UpdateFailed(
                     f"Connection error while connecting to Fujitsu Cloud: {err}"
                 ) from err
 
@@ -117,7 +119,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 asyncio.TimeoutError,
                 aiohttp.ServerTimeoutError,
             ) as err:
-                raise ConfigEntryNotReady(
+                raise UpdateFailed(
                     f"Connection error while connecting to {device_ip}: {err}"
                 ) from err
 


### PR DESCRIPTION
### Summary

Both coordinator update methods raise a **setup-time** exception on a **polling** failure:

- cloud path → `PlatformNotReady`
- local path → `ConfigEntryNotReady`

Neither is part of the `DataUpdateCoordinator` contract, so neither is matched by `_async_refresh`'s except chain. Both land in the final broad handler:

```python
except Exception as err:
    self.last_exception = err
    self.last_update_success = False
    self.logger.exception("Unexpected error fetching %s data", self.name)
```

### What this does and does not fix

**It does not fix recovery.** I want to be explicit about that, since it is the first thing one assumes. The broad handler still sets `last_update_success = False`, polling continues on schedule, and entities still come back on the next successful poll. `async_config_entry_first_refresh` still ends up raising `ConfigEntryNotReady`, just incidentally (via `last_update_success`) rather than through the documented path.

**What it fixes is the logging.** Compare the two handlers — the `UpdateFailed` branch:

```python
if self.last_update_success:
    if log_failures:
        self.logger.error("Error fetching %s data: %s", self.name, err)
        self.logger.debug("Full error:", exc_info=True)
    self.last_update_success = False
```

Two differences matter:

| | today (broad handler) | with `UpdateFailed` |
|---|---|---|
| logger call | `.exception()` → full traceback at ERROR | `.error()` one line; traceback at DEBUG |
| repeat guard | none — fires on **every** poll | `if self.last_update_success:` — logs once, on the transition into failure |

So an unreachable unit currently emits a full traceback at ERROR level on *every* poll. With `AIRSTAGE_SYNC_LOCAL_INTERVAL = 10` that is a traceback every ten seconds for as long as the device is down. That is a plausible contributor to how noisy the logs look in reports like #81 and #109 — though I'm not claiming it as the root cause of either.

Raising `UpdateFailed` also restores two behaviours the current code cannot reach at all: `retry_after` support, and the documented first-refresh conversion.

### Scope

Deliberately minimal — only the two `raise` statements and the import. Messages and the caught exception tuples are untouched.

I left out a related change I'd be happy to submit separately: `pyairstage` can leak non-`ApiError` failures (`KeyError`/`ValueError`/`TypeError`, and `OSError` on the cloud token file) that hit the same broad handler. Converting those to `UpdateFailed` too would be consistent, but it widens what gets swallowed, so it felt like a separate conversation.

### Verification

Static only — `py_compile`, plus confirming no remaining references to the dropped imports and that the `asyncio` / `aiohttp` imports are still used by the local except tuple. The `_async_refresh` quotes above are from current `home-assistant/core` `dev`.
