### PR TITLE
fix(resilience): entity properties must not raise

### DIFF
--- a/custom_components/fujitsu_airstage/climate.py
+++ b/custom_components/fujitsu_airstage/climate.py
@@ -31,7 +31,7 @@ from .const import (
     MINIMUM_HEAT,
     VERTICAL_SWING,
 )
-from .entity import AirstageAcEntity
+from .entity import READ_ERRORS, AirstageAcEntity
 from .models import AirstageData
 
 HA_STATE_TO_FUJITSU = {
@@ -169,7 +169,12 @@ class AirstageAC(AirstageAcEntity, ClimateEntity):
     @property
     def target_temperature(self) -> float | None:
         """Return the current target temperature."""
-        target_temp = self._ac.get_target_temperature()
+        try:
+            target_temp = self._ac.get_target_temperature()
+        except READ_ERRORS as e:
+            _LOGGER.debug("Could not read target temperature", exc_info=e)
+            return self.current_temperature
+
         if (
             self.hvac_mode == HVACMode.FAN_ONLY
             or target_temp is None
@@ -181,12 +186,24 @@ class AirstageAC(AirstageAcEntity, ClimateEntity):
     @property
     def min_temp(self) -> float | None:
         """Return the minimum temperature for the current mode."""
-        return self._ac.get_minimum_temperature() or constants.ACConstants.COOL_MIN_TEMP
+        try:
+            value = self._ac.get_minimum_temperature()
+        except READ_ERRORS as e:
+            _LOGGER.debug("Could not read minimum temperature", exc_info=e)
+            value = None
+
+        return value or constants.ACConstants.COOL_MIN_TEMP
 
     @property
     def max_temp(self) -> float | None:
         """Return the maximum temperature for the current mode."""
-        return self._ac.get_maximum_temperature() or constants.ACConstants.HEAT_MAX_TEMP
+        try:
+            value = self._ac.get_maximum_temperature()
+        except READ_ERRORS as e:
+            _LOGGER.debug("Could not read maximum temperature", exc_info=e)
+            value = None
+
+        return value or constants.ACConstants.HEAT_MAX_TEMP
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
@@ -207,20 +224,38 @@ class AirstageAC(AirstageAcEntity, ClimateEntity):
     @property
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        return self._ac.get_display_temperature()
+        try:
+            return self._ac.get_display_temperature()
+        except READ_ERRORS as e:
+            _LOGGER.debug("Could not read display temperature", exc_info=e)
+            return None
 
     @property
     def hvac_mode(self) -> HVACMode | None:
         """Return the current HVAC modes."""
-        om = self._ac.get_operating_mode()
+        try:
+            om = self._ac.get_operating_mode()
+        except READ_ERRORS as e:
+            # Report "unknown" rather than a fabricated OFF: an automation
+            # asking "is it off?" must not be told yes because a poll came
+            # back partial while the unit is actually running.
+            _LOGGER.debug("Could not determine operating mode", exc_info=e)
+            return None
+
         if om:
-            return FUJITSU_TO_HA_STATE[om]
+            return FUJITSU_TO_HA_STATE.get(om, HVACMode.OFF)
         return HVACMode.OFF
 
     @property
     def fan_mode(self) -> str | None:
         """Return the current fan modes."""
-        return FUJITSU_FAN_TO_HA[self._ac.get_fan_speed()]
+        try:
+            fan = self._ac.get_fan_speed()
+        except READ_ERRORS as e:
+            _LOGGER.debug("Could not determine fan speed", exc_info=e)
+            return None
+
+        return FUJITSU_FAN_TO_HA.get(fan) if fan is not None else None
 
     @property
     def swing_mode(self) -> str | None:
@@ -236,8 +271,12 @@ class AirstageAC(AirstageAcEntity, ClimateEntity):
 
             if self._ac.get_vertical_direction() != None:
                 return fujitsu_swing_to_ha(self._ac.get_vertical_direction())
-        except TypeError as e:
-            # #89 attempting to add some resillience until we can harden pyairstage
+        except READ_ERRORS as e:
+            # #89 attempting to add some resillience until we can harden
+            # pyairstage. Widened from TypeError for #115 / #119: an
+            # unsupported total_positions raises AirstageACError, which is not
+            # a TypeError, so it escaped here into supported_features and took
+            # the whole climate entity down with it.
             _LOGGER.debug("Could not determine swing state", exc_info=e)
             return None
 
@@ -245,7 +284,12 @@ class AirstageAC(AirstageAcEntity, ClimateEntity):
     def swing_modes(self) -> list[str] | None:
         """Return swing modes if supported."""
         if self.swing_mode:
-            total_positions = self._ac.get_num_vertical_swing_positions()
+            try:
+                total_positions = self._ac.get_num_vertical_swing_positions()
+            except READ_ERRORS as e:
+                _LOGGER.debug("Could not read swing positions", exc_info=e)
+                return None
+
             if total_positions == 8:
                 return SWING_MODES_8
             elif total_positions == 6:
@@ -253,17 +297,33 @@ class AirstageAC(AirstageAcEntity, ClimateEntity):
             elif total_positions == 4:
                 return SWING_MODES_4
             else:
-                raise ValueError(
-                    f"Unknown number of vertical swing positions ({total_positions}). Only 4, 6, and 8 are supported."
+                # Was `raise ValueError`. Raising from a property is what
+                # removes the entity; a unit that reports a position count we
+                # cannot map simply has no swing modes to offer.
+                _LOGGER.debug(
+                    "Unsupported number of vertical swing positions (%s); "
+                    "only 4, 6 and 8 are mapped",
+                    total_positions,
                 )
+                return None
         return None
+
+    @property
+    def _minimum_heat(self):
+        """Return the minimum-heat state, or None if it cannot be read."""
+        try:
+            return self._ac.get_minimum_heat()
+        except READ_ERRORS as e:
+            _LOGGER.debug("Could not determine minimum heat state", exc_info=e)
+            return None
 
     @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode."""
 
-        if self._ac.get_minimum_heat() != None:
-            if self._ac.get_minimum_heat() == constants.BooleanDescriptors.ON:
+        minimum_heat = self._minimum_heat
+        if minimum_heat != None:
+            if minimum_heat == constants.BooleanDescriptors.ON:
                 return MINIMUM_HEAT
             else:
                 return PRESET_NONE
@@ -272,11 +332,7 @@ class AirstageAC(AirstageAcEntity, ClimateEntity):
     @property
     def preset_modes(self) -> list[str] | None:
         """Return preset modes if supported."""
-        return (
-            [PRESET_NONE, MINIMUM_HEAT]
-            if self._ac.get_minimum_heat() is not None
-            else None
-        )
+        return [PRESET_NONE, MINIMUM_HEAT] if self._minimum_heat is not None else None
 
     async def async_update(self) -> None:
         """Retrieve latest state."""

--- a/custom_components/fujitsu_airstage/entity.py
+++ b/custom_components/fujitsu_airstage/entity.py
@@ -1,15 +1,26 @@
 """Airstage parent entity class."""
 
+import logging
+from collections.abc import Callable
 from typing import Any
 
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from pyairstage.airstageAC import AirstageAC
+from pyairstage.airstageAC import AirstageAC, AirstageACError
 from pyairstage.airstageApi import ApiError
 
 from .const import DOMAIN
 from .models import AirstageData
+
+# Reading a value back out of pyairstage can fail on partial or unexpected
+# cached data: AirstageACError for a value the library refuses to interpret
+# (e.g. an unsupported total_positions), TypeError/ValueError/KeyError when a
+# parameter is absent or does not convert. An entity *property* must never let
+# these escape -- see the module docstrings at each call site.
+READ_ERRORS = (AirstageACError, TypeError, ValueError, KeyError)
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class AirstageEntity(CoordinatorEntity):
@@ -63,6 +74,22 @@ class AirstageAcEntity(AirstageEntity):
         return AirstageAC(self.ac_key, self.instance.api).refresh_parameters(
             data=self.coordinator.data[self.ac_key]
         )
+
+    def read(self, getter: Callable[[AirstageAC], Any], default: Any = None) -> Any:
+        """Read a value from pyairstage, degrading to ``default`` on failure.
+
+        ``getter`` receives the ``AirstageAC`` rather than being a bound
+        method so that building it happens *inside* the guarded block: a
+        device missing from the coordinator's cache raises before any getter
+        would run.
+        """
+        try:
+            return getter(self._ac)
+        except READ_ERRORS as e:
+            _LOGGER.debug(
+                "Airstage read failed for %s", self.entity_id or self.ac_key, exc_info=e
+            )
+            return default
 
     @property
     def extra_state_attributes(self) -> dict:

--- a/custom_components/fujitsu_airstage/sensor.py
+++ b/custom_components/fujitsu_airstage/sensor.py
@@ -84,9 +84,10 @@ class AirstageTemp(AirstageAcEntity, SensorEntity):
         """Return the current value of the measured temperature."""
         # value = self._ac.get_device_parameter(self.parameter)
         if self.parameter is constants.ACParameter.INDOOR_TEMPERATURE:
-            value = self._ac.get_display_temperature()
-            return Decimal(value) if value is not None else None
+            value = self.read(lambda ac: ac.get_display_temperature())
+        elif self.parameter is constants.ACParameter.OUTDOOR_TEMPERATURE:
+            value = self.read(lambda ac: ac.get_outdoor_temperature())
+        else:
+            return None
 
-        if self.parameter is constants.ACParameter.OUTDOOR_TEMPERATURE:
-            value = self._ac.get_outdoor_temperature()
-            return Decimal(value) if value is not None else None
+        return Decimal(value) if value is not None else None

--- a/custom_components/fujitsu_airstage/switch.py
+++ b/custom_components/fujitsu_airstage/switch.py
@@ -64,7 +64,10 @@ class AirstageEcoSwitch(AirstageAcEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return the eco mode status."""
-        return self._ac.get_economy_mode() == constants.BooleanDescriptors.ON
+        return (
+            self.read(lambda ac: ac.get_economy_mode())
+            == constants.BooleanDescriptors.ON
+        )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn eco mode on."""
@@ -92,7 +95,10 @@ class AirstagePowerfulSwitch(AirstageAcEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return the powerful status."""
-        return self._ac.get_powerful_mode() == constants.BooleanDescriptors.ON
+        return (
+            self.read(lambda ac: ac.get_powerful_mode())
+            == constants.BooleanDescriptors.ON
+        )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn powerful on."""
@@ -120,7 +126,10 @@ class AirstageOutdoorLowNoiseSwitch(AirstageAcEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return the outdoor unit low noise" status."""
-        return self._ac.get_outdoor_low_noise() == constants.BooleanDescriptors.ON
+        return (
+            self.read(lambda ac: ac.get_outdoor_low_noise())
+            == constants.BooleanDescriptors.ON
+        )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn outdoor unit low noise" on."""
@@ -148,7 +157,10 @@ class AirstageEnergySaveFanSwitch(AirstageAcEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return the energy saving fan status."""
-        return self._ac.get_energy_save_fan() == constants.BooleanDescriptors.ON
+        return (
+            self.read(lambda ac: ac.get_energy_save_fan())
+            == constants.BooleanDescriptors.ON
+        )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn energy saving fan on."""
@@ -176,7 +188,10 @@ class AirstageQuietFanSwitch(AirstageAcEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return the quiet fan status."""
-        return self._ac.get_fan_speed() == constants.FanSpeedDescriptors.QUIET
+        return (
+            self.read(lambda ac: ac.get_fan_speed())
+            == constants.FanSpeedDescriptors.QUIET
+        )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn quiet fan on."""
@@ -203,7 +218,9 @@ class AirstageIndoorLedSwitch(AirstageAcEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return the energy saving fan status."""
-        return self._ac.get_indoor_led() == constants.BooleanDescriptors.ON
+        return (
+            self.read(lambda ac: ac.get_indoor_led()) == constants.BooleanDescriptors.ON
+        )
 
     @property
     def icon(self) -> str:
@@ -237,7 +254,10 @@ class AirstagePowerSwitch(AirstageAcEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return the power status."""
-        return self._ac.get_device_on_off_state() == constants.BooleanDescriptors.ON
+        return (
+            self.read(lambda ac: ac.get_device_on_off_state())
+            == constants.BooleanDescriptors.ON
+        )
 
     @property
     def icon(self) -> str:
@@ -272,7 +292,10 @@ class AirstageHumanDetectionAutoSaveSwitch(AirstageAcEntity, SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return the Human Detection Auto Save status."""
-        return self._ac.get_hmn_detection_auto_save() == constants.BooleanDescriptors.ON
+        return (
+            self.read(lambda ac: ac.get_hmn_detection_auto_save())
+            == constants.BooleanDescriptors.ON
+        )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn Human Detection Auto Save on."""


### PR DESCRIPTION
### The failure mode #119 exposed

pyairstage 3.2.1 returned a `total_positions` of 0, `get_vertical_direction()` raised `AirstageACError`, and `swing_mode` caught only `TypeError` — so the error escaped:

```
Error adding entity None for domain climate with platform fujitsu_airstage
→ climate.py line 340, supported_features
→ climate.py line 237, swing_mode
→ Invalid total_positions value: 0. Only 4, 6 and 8 are supported
```

The whole climate entity failed to be added while the switches kept working — exactly what the reporter described. `AirstageACError` derives straight from `Exception`, so no amount of `except TypeError` was ever going to catch it. Same root shape as #115, and #89 before it.

1.8.4 fixed *that* occurrence by pinning `pyairstage>=3.2.2`. This PR addresses the other half: **a library-level error should cost one unknown attribute, not the entity.** As it stands the integration is one bad library release away from the same outcome, which is now twice in 48 hours.

### What changed

- `swing_mode` catches the library's own error class rather than just `TypeError`.
- `swing_modes` returns `None` instead of `raise ValueError` for a position count it cannot map. Raising from a property is precisely what removes the entity; a unit reporting an unmappable count simply has no swing modes to offer.
- The same guard is applied to every other property reading through pyairstage — climate temperatures, `hvac_mode`, `fan_mode`, preset; sensor `native_value`; the eight switch `is_on`.

Reads go through a small `AirstageAcEntity.read()` helper. It takes a callable receiving the `AirstageAC` rather than a bound method, so that *building* it sits inside the guarded block — a device absent from the coordinator cache raises before any getter would run.

### Behaviour rule

**Only paths that previously raised change.** Where a read returns `None` today the result is unchanged — switch `is_on` still reports off for an unavailable capability rather than newly reporting unknown.

One deliberate exception: `hvac_mode` previously raised when the operating mode could not be read, and now returns `None`. It reports "unknown" rather than a fabricated `OFF`, so an automation asking "is it off?" is not told yes while the unit is running. Happy to drop that one if you would rather keep this PR purely mechanical.

### Verification

I walked the AST of all four entity modules looking for properties that can raise — an explicit `raise`, or a `self._ac` read not enclosed by a guard:

```
BEFORE (1.8.4)                          AFTER
climate.py:        11                   climate.py:        0
sensor.py:          2                   sensor.py:         0
switch.py:          8                   switch.py:         0
binary_sensor.py:   0                   binary_sensor.py:  0
```

**Limitation worth stating:** that audit checks *structure* — whether a guard exists — not which exceptions it names. `swing_mode` counted as guarded in both columns, since it always had a `try`; its catch was simply too narrow. So the audit would not have caught #119, and it is evidence of coverage, not of correctness. The `AirstageACError` widening rests on reading `pyairstage/airstageAC.py`, where `class AirstageACError(Exception)` and the `Invalid total_positions value` raise sites are.

Otherwise static only: `py_compile`, and hand-formatting to black's 88 columns since I could not run the pre-commit hooks in this environment — worth a `pre-commit run` on your side.

### Scope

This is one principle applied uniformly, so it touches four files. If you would rather take it in two bites, the `swing_mode` / `swing_modes` part stands alone as the #119 fix and I will happily split the rest out.
